### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,13 @@
 # bin-bagit
 
-**bin-bagit** an experiment in building a Docker image containing
+**bin-bagit** is an experiment in building a Docker image containing
 <https://github.com/LibraryOfCongress/bagit-python> as a single file binary.
 
 **bin-bagit** uses:
 
 - <https://github.com/astral-sh/uv> for Python package management
-- <https://github.com/six8/pyinstaller-alpine> to build the single file binary for
-  Alpine Linux from the `bagit-python` package
-
-## Notes
-
-- `setuptools` is a dependency for <https://pypi.org/project/bagit/1.8.1/> (it
-  imports  `pkg_resources`) but is not in listed in the `requirements.txt` file.
-- The `pkg_resources` import has been removed from the bagit-python git
-  repository as of <https://github.com/LibraryOfCongress/bagit-python/commit/44f21392604e3930af9f0b6f9f0937ea3d56fe2e> but I haven't taken the time to
-  build `bagit-python` from the source.
+- <https://pyinstaller.org/> to build the single file binary from the
+  `bagit-python` package
 
 ## Usage
 


### PR DESCRIPTION
This commit updates the build to install PyInstaller via pip (`six8/pyinstaller-alpine` hasn't been updated in 4 years). As a result of this change, the final binary now depends on glibc instead of musl, so we're also switching to a glibc-based distribution for the runtime image.

Since PyInstaller now shares the venv with bagit-python, it appears to be able to locate and bundle setuptools. I believe setuptools is installed because it's a dependency of setuptools_scm which is listed in the setup.py. This means we no longer need to manually install setuptools.

I've also taken this opportunity to upgrade Python to 3.13, as 3.8 reached its end of life (EOL) a few days ago.